### PR TITLE
Avoid redefining LITTLE/BIG_ENDIAN

### DIFF
--- a/parse_script.c
+++ b/parse_script.c
@@ -86,11 +86,11 @@ int encodeScript(FILE* infile, FILE* outfile){
     }
     pInput = strtok(NULL, "()\t = \r\n");
     if (strcmp(pInput, "big") == 0) {
-        output_endian_type = BIG_ENDIAN;
+        output_endian_type = LUNAR_BIG_ENDIAN;
         printf("Setting Big Endian.\n");
     }
     else if (strcmp(pInput, "little") == 0){
-        output_endian_type = LITTLE_ENDIAN;
+        output_endian_type = LUNAR_LITTLE_ENDIAN;
         printf("Setting Little Endian.\n");
     }
     else{

--- a/script_node_types.h
+++ b/script_node_types.h
@@ -6,8 +6,8 @@
 /***********/
 
 /* Binary Output Mode */
-#define BIG_ENDIAN    0
-#define LITTLE_ENDIAN 1
+#define LUNAR_BIG_ENDIAN    0
+#define LUNAR_LITTLE_ENDIAN 1
 
 /* Meta Script Read Mode for data values */
 #define RADIX_DEC     0

--- a/test/util.c
+++ b/test/util.c
@@ -58,7 +58,7 @@ static int numEntries = 0;
 
 /* I/O Globals*/
 static int textDecodeMode = TEXT_DECODE_TWO_BYTES_PER_CHAR;  //Binary Input File Encoding for Text
-static int outputMode = BIG_ENDIAN;  //Script Text File Value Encoding
+static int outputMode = LUNAR_BIG_ENDIAN;  //Script Text File Value Encoding
 static int inputMode = RADIX_HEX;    //Script Text File Value Representation
 static int tableMode = TWO_BYTE_ENC; //Table File Encoding Method
 static unsigned int maxBinFsize = 0; //MAX allowed size of a binary script file
@@ -299,13 +299,13 @@ int getUTF8code_Short(char* utf8Value, unsigned short* utf8Code){
 
 
 void setBinOutputMode(int mode){
-    if (mode == BIG_ENDIAN)
-        outputMode = BIG_ENDIAN;
-    else if (mode == LITTLE_ENDIAN)
-        outputMode = LITTLE_ENDIAN;
+    if (mode == LUNAR_BIG_ENDIAN)
+        outputMode = LUNAR_BIG_ENDIAN;
+    else if (mode == LUNAR_LITTLE_ENDIAN)
+        outputMode = LUNAR_LITTLE_ENDIAN;
     else{
         printf("Invalid Output Mode, defaulting to Big Endian.\n");
-        outputMode = BIG_ENDIAN;
+        outputMode = LUNAR_BIG_ENDIAN;
     }
     return;
 }

--- a/test/write_script.c
+++ b/test/write_script.c
@@ -58,7 +58,7 @@ static int writeLW(unsigned int data){
         return -1;
     }
 
-    if (output_endian_type == LITTLE_ENDIAN){
+    if (output_endian_type == LUNAR_LITTLE_ENDIAN){
         *pData = data;
     }
     else{
@@ -100,7 +100,7 @@ static int writeSW(unsigned short data){
         return -1;
     }
 
-    if (output_endian_type == LITTLE_ENDIAN){
+    if (output_endian_type == LUNAR_LITTLE_ENDIAN){
         *pData = data;
     }
     else{
@@ -895,7 +895,7 @@ int writeScript(FILE* outFile){
 
     /* Output Header */
     fprintf(outFile, "(start\r\n");
-    if( getBinOutputMode() == BIG_ENDIAN)
+    if( getBinOutputMode() == LUNAR_BIG_ENDIAN)
         fprintf(outFile, "    (endian=big)\r\n");
     else
         fprintf(outFile, "    (endian=little)\r\n");

--- a/util.c
+++ b/util.c
@@ -58,7 +58,7 @@ static int numEntries = 0;
 
 /* I/O Globals*/
 static int textDecodeMode = TEXT_DECODE_TWO_BYTES_PER_CHAR;  //Binary Input File Encoding for Text
-static int outputMode = BIG_ENDIAN;  //Script Text File Value Encoding
+static int outputMode = LUNAR_BIG_ENDIAN;  //Script Text File Value Encoding
 static int inputMode = RADIX_HEX;    //Script Text File Value Representation
 static int tableMode = TWO_BYTE_ENC; //Table File Encoding Method
 static unsigned int maxBinFsize = 0; //MAX allowed size of a binary script file
@@ -299,13 +299,13 @@ int getUTF8code_Short(char* utf8Value, unsigned short* utf8Code){
 
 
 void setBinOutputMode(int mode){
-    if (mode == BIG_ENDIAN)
-        outputMode = BIG_ENDIAN;
-    else if (mode == LITTLE_ENDIAN)
-        outputMode = LITTLE_ENDIAN;
+    if (mode == LUNAR_BIG_ENDIAN)
+        outputMode = LUNAR_BIG_ENDIAN;
+    else if (mode == LUNAR_LITTLE_ENDIAN)
+        outputMode = LUNAR_LITTLE_ENDIAN;
     else{
         printf("Invalid Output Mode, defaulting to Big Endian.\n");
-        outputMode = BIG_ENDIAN;
+        outputMode = LUNAR_BIG_ENDIAN;
     }
     return;
 }

--- a/write_script.c
+++ b/write_script.c
@@ -58,7 +58,7 @@ static int writeLW(unsigned int data){
         return -1;
     }
 
-    if (output_endian_type == LITTLE_ENDIAN){
+    if (output_endian_type == LUNAR_LITTLE_ENDIAN){
         *pData = data;
     }
     else{
@@ -100,7 +100,7 @@ static int writeSW(unsigned short data){
         return -1;
     }
 
-    if (output_endian_type == LITTLE_ENDIAN){
+    if (output_endian_type == LUNAR_LITTLE_ENDIAN){
         *pData = data;
     }
     else{
@@ -895,7 +895,7 @@ int writeScript(FILE* outFile){
 
     /* Output Header */
     fprintf(outFile, "(start\r\n");
-    if( getBinOutputMode() == BIG_ENDIAN)
+    if( getBinOutputMode() == LUNAR_BIG_ENDIAN)
         fprintf(outFile, "    (endian=big)\r\n");
     else
         fprintf(outFile, "    (endian=little)\r\n");


### PR DESCRIPTION
Some OSs include constants by these names already; prefixing these definitions avoids redefining the OS versions. macOS is an example of an OS that has builtin constants with these names.