### PR TITLE
util: fix passing char ** to sscanf instead of char *

### DIFF
--- a/util.c
+++ b/util.c
@@ -446,7 +446,7 @@ int readBYTE(unsigned char* pInput, unsigned char* datab){
         *datab = local & 0xFF;
     }
     else{
-        if (sscanf(pInput, "%c", &datab) != 1){
+        if (sscanf(pInput, "%c", datab) != 1){
             printf("Error reading byte\n");
             return -1;
         }


### PR DESCRIPTION
As noted by clang:

```
util.c:449:34: warning: format specifies type 'char *' but the argument has type 'unsigned char **' [-Wformat]
        if (sscanf(pInput, "%c", &datab) != 1){
                            ~~   ^~~~~~
```