### PR TITLE
dumpScript: remember to actually use all parameters

### DIFF
--- a/write_script.c
+++ b/write_script.c
@@ -1562,7 +1562,7 @@ int dumpScript(FILE* outFile, FILE* txtOutFile){
 					/* MVKILL */
 					case 0x0035:
 					{
-						fprintf(outFile, "\tMVKILL\r\n", (pNode->subParams[0].value & 0xFF00) >> 8);
+						fprintf(outFile, "\tMVKILL%u\r\n", (pNode->subParams[0].value & 0xFF00) >> 8);
 						break;
 					}
 
@@ -2095,7 +2095,7 @@ int dumpScript(FILE* outFile, FILE* txtOutFile){
 
 				fprintf(outFile, "\t%u", pNode->id);
 
-				fprintf(outFile, "\tTALK", pNode->id);
+				fprintf(outFile, "\tTALK%u", pNode->id);
 
 				while (rpNode != NULL) {
 


### PR DESCRIPTION
clang flagged the issue that the format string didn't actually make use of the argument that was being passed to it. Based on context, I'm not 100% sure if this is the right place to interpolate the string or if it doesn't need to be used at all.