### PR TITLE
parse_script: remove unused variable

### DIFF
--- a/parse_script.c
+++ b/parse_script.c
@@ -16,7 +16,6 @@
 
 /* Globals */
 static unsigned char* pInput = NULL;
-static int G_table_mode = ONE_BYTE_ENC;         /* Copy of Table Conversion Mode */
 static int radix_type = RADIX_HEX;
 
 /* Function Prototypes */


### PR DESCRIPTION
I noticed this is used in another file, but not in this one.